### PR TITLE
Make localStorage optional

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,9 @@
+const localStorage = window.localStorage || {
+  getItem: () => null,
+  setItem: () => {},
+  clear: () => {},
+};
+
 const ALL_KANA = {
   hiragana: {
     monographs: {
@@ -256,7 +262,6 @@ function loadTemplates() {
 }
 
 function runGame() {
-  let localStorage = window.localStorage;
   let timerElement = document.getElementById('timer');
   let answerFieldElement = document.getElementById('answer_field');
   let currentKanaElement = document.getElementById('current_kana');
@@ -286,7 +291,7 @@ function runGame() {
 }
 
 function reset() {
-  window.localStorage.clear();
+  localStorage.clear();
   window.location.reload();
 }
 
@@ -345,11 +350,11 @@ updateStats(kana, score) {
     this.kanaStats[this.curKanaChallange] = score;
   }
   this.gameSettings.lastScoreElement.textContent = score.toFixed(2).toString();
-  window.localStorage.setItem('kanaStats', JSON.stringify(this.kanaStats));
+  localStorage.setItem('kanaStats', JSON.stringify(this.kanaStats));
 }
 
 persistGameSettings() {
-  window.localStorage.setItem('kanaSettings', JSON.stringify(this.gameSettings.kanaSettings));
+  localStorage.setItem('kanaSettings', JSON.stringify(this.gameSettings.kanaSettings));
 }
 
 nextKana() {


### PR DESCRIPTION
Use `window.localStorage` when available, otherwise fallback to a dummy implementation that does nothing.

### Reason

I'm using a Firefox profile with a bunch of features disabled, among them `localStorage`.

This causes the script to crash [when trying to load the stored settings](https://github.com/Anpanator/kanaGemu/blob/137a54df8f9fe3102bcda54728c83c547919de59/app.js#L273) because `localStorage` is `null` in the line `localStorage.getItem('kanaSettings');`.